### PR TITLE
Resolutions for iPhone 14 devices

### DIFF
--- a/_subpages/res.md
+++ b/_subpages/res.md
@@ -35,19 +35,12 @@ redirect_from:
     <td class="nowrap">
       <span class="strong">iPhone 14 Pro</span><br>
     </td>
-    <td rowspan="2">6.1"</td>
+    <td>6.1"</td>
     <td>393 × 852</td>
-    <td rowspan="6">@3x</td>
+    <td rowspan="4">@3x</td>
     <td>1179 × 2556</td>
-    <td rowspan="10">9 : 19.5</td>
-    <td rowspan="3">460</td>
-  </tr>
-  <tr>
-    <td class="nowrap">
-      <span class="strong">iPhone 14</span><br>
-    </td>
-    <td>390 × 844</td>
-    <td>1170 × 2532</td>
+    <td rowspan="8">9 : 19.5</td>
+    <td rowspan="2">460</td>
   </tr>
   <tr>
     <td class="nowrap">
@@ -60,24 +53,17 @@ redirect_from:
   <tr>
     <td class="nowrap">
       <span class="strong">iPhone 14 Plus</span><br>
-    </td>
-    <td>428 × 926</td>
-    <td>1284 x 2778</td>
-    <td>458</td>
-  </tr>
-  <tr>
-    <td class="nowrap">
-      <span class="strong">iPhone 13 Pro Max</span><br>
+      <span class="soft">and 13 Pro Max</span><br>
       <span class="soft">and 12 Pro Max</span>
     </td>
-    <td>6.7"</td>
     <td>428 × 926</td>
     <td>1284 × 2778</td>
     <td>458</td>
   </tr>
   <tr>
     <td class="nowrap">
-      <span class="strong">iPhone 13 / 13 Pro</span><br>
+      <span class="strong">iPhone 14</span><br>
+      <span class="soft">and 13 / 13 Pro</span><br>
       <span class="soft">and 12 / 12 Pro</span>
     </td>
     <td>6.1"</td>

--- a/_subpages/res.md
+++ b/_subpages/res.md
@@ -33,14 +33,46 @@ redirect_from:
   </tr>
   <tr>
     <td class="nowrap">
+      <span class="strong">iPhone 14 Pro</span><br>
+    </td>
+    <td rowspan="2">6.1"</td>
+    <td>393 × 852</td>
+    <td rowspan="6">@3x</td>
+    <td>1179 × 2556</td>
+    <td rowspan="10">9 : 19.5</td>
+    <td rowspan="3">460</td>
+  </tr>
+  <tr>
+    <td class="nowrap">
+      <span class="strong">iPhone 14</span><br>
+    </td>
+    <td>390 × 844</td>
+    <td>1170 × 2532</td>
+  </tr>
+  <tr>
+    <td class="nowrap">
+      <span class="strong">iPhone 14 Pro Max</span><br>
+    </td>
+    <td rowspan="2">6.7"</td>
+    <td>430 × 932</td>
+    <td>1290 × 2796</td>
+  </tr>
+  <tr>
+    <td class="nowrap">
+      <span class="strong">iPhone 14 Plus</span><br>
+    </td>
+    <td>428 × 926</td>
+    <td>1284 x 2778</td>
+    <td>458</td>
+  </tr>
+  <tr>
+    <td class="nowrap">
       <span class="strong">iPhone 13 Pro Max</span><br>
       <span class="soft">and 12 Pro Max</span>
     </td>
     <td>6.7"</td>
     <td>428 × 926</td>
-    <td rowspan="2">@3x</td>
     <td>1284 × 2778</td>
-    <td rowspan="6">9 : 19.5</td>
     <td>458</td>
   </tr>
   <tr>


### PR DESCRIPTION
I'm not sure what conventions exist here - row ordering and such - so I'm open to tweaks.

The aspect ratio in particular is interesting - how precise should it be? 9:19.5 fits all of them pretty close.

iPhone 14 Pro: 2556 x 1179. 1179 * (19.5 / 9) = 2554.5
iPhone 14 Pro Max: 2796 x 1290. 1290 * (19.5 / 9) = 2795
iPhone 14: 2532 x 1170. 1170 * (19.5 / 9) = 2535
iPhone 14 Plus: 2778 x 1284. 1284 * (19.5 / 9) = 2782