### PR TITLE
Allow '0x' prefix for hex color input #46

### DIFF
--- a/_subpages/uihex.html
+++ b/_subpages/uihex.html
@@ -13,7 +13,7 @@ redirect_from:
 <div id="uihex">
   <div id="input-container">
     <div class="color-preview"></div>
-    <input type="text" id="hex-value" placeholder="Hex Code" maxlength="9" value="">
+    <input type="text" id="hex-value" placeholder="Hex Code" maxlength="10" value="">
     <div class="color-preview active"></div>
   </div>
 

--- a/js/uihex.js
+++ b/js/uihex.js
@@ -11,14 +11,14 @@ $(document).ready(function() {
 });
 
 function processValue(value) {
-  const hexWithoutHash = (value[0] == '#') ? value.substring(1) : value;
+  const hexWithoutPrefix = (value[0] == '#') ? value.substring(1) : value[1] == 'x' ? value.substring(2) : value;
   
-  if (!validateHexLength(hexWithoutHash)) {
+  if (!validateHexLength(hexWithoutPrefix)) {
     clearResults();
     return;
   }
   
-  const hexLowercased = hexWithoutHash.toLowerCase();
+  const hexLowercased = hexWithoutPrefix.toLowerCase();
   const hexFullLength = fullLengthValueForAnalyzing(hexLowercased);
   const hexFullLengthForDisplay = hexLowercased;
 


### PR DESCRIPTION
This should fix #46 by cutting '0x' off & allowing one extra character for the input field.

I have not rigorously tested it, but it does work on my machine ;)