### PR TITLE
fixed: cell pos + added mini 6 ratio

### DIFF
--- a/_subpages/res.md
+++ b/_subpages/res.md
@@ -35,9 +35,12 @@ redirect_from:
     <td class="nowrap">
       <span class="strong">iPhone 16 Pro Max</span>
     </td>
-    <td rowspan="2">6.9"</td>
+    <td rowspan="1">6.9"</td>
+    <td rowspan="5">@3x</td>
     <td>440 × 956</td>
     <td>1320 × 2868</td>
+    <td rowspan="9">9 : 19.5</td>
+    <td rowspan="3">460</td>
   </tr>
   <tr>
     <td class="nowrap">
@@ -48,10 +51,7 @@ redirect_from:
     </td>
     <td>6.1"</td>
     <td>393 × 852</td>
-    <td rowspan="4">@3x</td>
     <td>1179 × 2556</td>
-    <td rowspan="8">9 : 19.5</td>
-    <td rowspan="2">460</td>
   </tr>
   <tr>
     <td class="nowrap">
@@ -202,10 +202,10 @@ redirect_from:
     </td>
     <td>13"</td>
     <td class="nowrap">1032 × 1376</td>
-    <td rowspan="9">@2x</td>
+    <td rowspan="11">@2x</td>
     <td class="nowrap">2064 × 2752</td>
-    <td rowspan="2">3 : 4</td>
-    <td rowspan="5">264</td>
+    <td rowspan="4">3 : 4</td>
+    <td rowspan="7">264</td>
   </tr>
   <tr>
     <td>
@@ -213,10 +213,7 @@ redirect_from:
     </td>
     <td>12.9"</td>
     <td class="nowrap">1024 × 1366</td>
-    <td rowspan="9">@2x</td>
     <td class="nowrap">2048 × 2732</td>
-    <td rowspan="2">3 : 4</td>
-    <td rowspan="5">264</td>
   </tr>
   <tr>
     <td>
@@ -224,10 +221,7 @@ redirect_from:
     </td>
     <td>11"</td>
     <td class="nowrap">834 × 1210</td>
-    <td rowspan="9">@2x</td>
     <td class="nowrap">1668 × 2420</td>
-    <td rowspan="2">3 : 4</td>
-    <td rowspan="5">264</td>
   </tr>
   <tr>
     <td>
@@ -267,7 +261,7 @@ redirect_from:
     <td>8.3"</td>
     <td>744 × 1133</td>
     <td>1488 × 2266</td>
-    <td>?</td>
+    <td>2 : 3</td>
     <td>326</td>
   </tr>
   <tr>


### PR DESCRIPTION
This PR:
- adds the missing aspect ratio of the Mini 6 (it's basically a 2 : 3) display 
- fixed cells alignments issues:
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/3641d097-91a7-4b3a-8e05-c163facb708e">
<img width="1666" alt="image" src="https://github.com/user-attachments/assets/28ead446-129c-414f-a09d-8c9de7cc45bf">
