### PR TITLE
Fix the Actual Resolution/Aspect ratio column order in res.md

### DIFF
--- a/_subpages/res.md
+++ b/_subpages/res.md
@@ -42,8 +42,8 @@ redirect_from:
         <td>6.9"</td>
         <td>440 × 956</td>
         <td rowspan="5">@3x</td>
-        <td rowspan="9">9 : 19.5</td>
         <td>1320 × 2868</td>
+        <td rowspan="9">9 : 19.5</td>
         <td>458</td>
       </tr>
       <tr>


### PR DESCRIPTION
The aspect ratio of iPhones with an 9 : 19.5 aspect ratio were shown under the "Actual resolution" column header; and all their actual resolutions were under the "Aspect ratio" header. This reverses the columns <td>s to fix this.